### PR TITLE
Investigate app crash on launch

### DIFF
--- a/AdSight/babel.config.js
+++ b/AdSight/babel.config.js
@@ -1,0 +1,7 @@
+module.exports = function (api) {
+  api.cache(true);
+  return {
+    presets: ['babel-preset-expo'],
+    plugins: ['react-native-reanimated/plugin'],
+  };
+};

--- a/AdSight/index.ts
+++ b/AdSight/index.ts
@@ -1,3 +1,4 @@
+import 'react-native-gesture-handler';
 import { registerRootComponent } from 'expo';
 
 import App from './App';


### PR DESCRIPTION
Fixes Android release startup crash by adding gesture-handler import and Reanimated Babel plugin.

The app was crashing immediately on launch in release builds due to two common React Native issues: the `react-native-gesture-handler` import was missing at the entry point, and the `babel.config.js` file with the `react-native-reanimated/plugin` was not present, both of which are critical for React Navigation and Reanimated to function correctly in production.

---
<a href="https://cursor.com/background-agent?bcId=bc-94d6064d-2a99-46f0-87e6-6eb2ef505748">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-94d6064d-2a99-46f0-87e6-6eb2ef505748">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

